### PR TITLE
On Page reload current template should be autoselected #issue-1951799800

### DIFF
--- a/apps/factory/src/components/prompt_template.tsx
+++ b/apps/factory/src/components/prompt_template.tsx
@@ -39,10 +39,17 @@ const PromptTemplate = ({
 
   // console.log(`pvs <<<<>>>> ${JSON.stringify(pvs)}`);
 
-  const [activeTab, setActiveTab] = useState(0);
+  const [activeTab, setActiveTab] = useState(() => {
+    if (typeof window !== "undefined") {
+      return parseInt(localStorage.getItem("activeVersion") || "0", 10);
+    } else {
+      return 0;
+    }
+  });
 
   const handleChangeTab = (event: any, newValue: number) => {
     setActiveTab(newValue);
+    localStorage.setItem("activeVersion", `${newValue}`);
   };
 
   const handleVersionCreate = (pv: any) => {

--- a/apps/factory/src/pages/dashboard/prompts/[id]/index.tsx
+++ b/apps/factory/src/pages/dashboard/prompts/[id]/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Typography,
   Box,
@@ -48,7 +48,14 @@ const PackageShow: NextPageWithLayout = () => {
     id: packageId,
   });
   // console.log(`pp <<<<>>>> ${JSON.stringify(pp)}`);
-  const [ptId, setPtId] = useState<string>("");
+  // const [ptId, setPtId] = useState<string>("");
+  const [ptId, setPtId] = useState<string>(() => {
+    if (typeof window !== "undefined") {
+      return localStorage.getItem("ptId") || "";
+    } else {
+      return "";
+    }
+  });
   const [pt, setPt] = useState<pt>();
 
   const { data: pts, refetch: rpts } = api.prompt.getTemplates.useQuery({
@@ -56,10 +63,17 @@ const PackageShow: NextPageWithLayout = () => {
   });
   // console.log(`pts <<<<>>>> ${JSON.stringify(pts)}`);
 
+  useEffect(() => {
+    setPt(pts?.find((pt) => pt.id == ptId));
+  });
+
   const handleTemplateSelection = (e: any) => {
     const id = e.target.value;
     setPtId(id);
     setPt(pts?.find((pt) => pt.id == id));
+    if (typeof window !== "undefined") {
+      localStorage.setItem("ptId", id);
+    }
   };
 
   const ptCreateMutation = api.prompt.createTemplate.useMutation({


### PR DESCRIPTION
issue -> https://github.com/sugarcane-ai/sugarcane-ai/issues/8#issue-1951799800

I've stored the state of both ptId and ActiveTab in localstorage as they are selected.
When ever the page is loaded, the ptId and ActiveTab both get fetched from localstorage and set as default value in state of the current page. 

A useEffect hook is called to map the pts using ptId allowing different versions to get loaded