### PR TITLE
Package list Screen #35

### DIFF
--- a/apps/factory/src/components/create_package.tsx
+++ b/apps/factory/src/components/create_package.tsx
@@ -23,10 +23,12 @@ export function CreatePackage({
   onSubmit,
   status,
   customError,
+  PackagesExits,
 }: {
   onSubmit: Function;
   status: string;
   customError: any;
+  PackagesExits: boolean;
 }) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -76,9 +78,9 @@ export function CreatePackage({
 
   return (
     <>
-      <Grid container justifyContent="flex-end">
+      <Grid container justifyContent={PackagesExits ? "flex-end" : "center"}>
         <Button size="small" variant="outlined" onClick={() => setIsOpen(true)}>
-          Create
+          Create Prompt Package
         </Button>
       </Grid>
 

--- a/apps/factory/src/pages/dashboard/prompts/index.tsx
+++ b/apps/factory/src/pages/dashboard/prompts/index.tsx
@@ -11,6 +11,7 @@ import {
   Snackbar,
   Alert,
   Chip,
+  Button,
 } from "@mui/material";
 import { CreatePackage } from "~/components/create_package";
 import UpdatePackage from "~/components/update_package";
@@ -75,6 +76,14 @@ function Packages() {
     });
   };
 
+  const truncateDescription = (description: string, maxLines: number) => {
+    const lines = description.split(" ");
+    if (lines.length <= maxLines * 10) {
+      return description;
+    }
+    return lines.slice(0, maxLines * 10).join(" ") + "...";
+  };
+
   return (
     <Grid container spacing={1}>
       {packages && packages.length > 0 ? (
@@ -82,9 +91,39 @@ function Packages() {
           <Grid item key={index} xs={12} sm={6} md={4} lg={3}>
             <Card>
               <CardHeader title={pkg?.name} />
-              <CardContent>
-                <Typography>{pkg?.description}</Typography>
-              </CardContent>
+              {pkg?.description ? (
+                <CardContent>
+                  <Typography
+                    variant="body2"
+                    style={{
+                      overflow: "hidden",
+                      height: "40px",
+                      textOverflow: "ellipsis",
+                      display: "-webkit-box",
+                      WebkitBoxOrient: "vertical",
+                      WebkitLineClamp: 2,
+                    }}
+                  >
+                    {truncateDescription(pkg?.description || "", 2)}
+                  </Typography>
+                </CardContent>
+              ) : (
+                <CardContent>
+                  <Typography
+                    variant="body2"
+                    style={{
+                      height: "40px",
+                      alignItems: "center",
+                      alignContent: "center",
+                      paddingBottom: "20px",
+                      fontSize: "17px",
+                      opacity: "60%",
+                    }}
+                  >
+                    {"No description entered"}
+                  </Typography>
+                </CardContent>
+              )}
               <CardActions>
                 <Chip
                   sx={{ mr: 2 }}
@@ -92,16 +131,47 @@ function Packages() {
                   label={pkg?.visibility}
                   // variant="conti"
                 />
-                <MUILink href={`/dashboard/prompts/${pkg?.id}`}>View</MUILink>
-                <MUILink href={`/dashboard/prompts/${pkg?.id}/logs`}>
+                {/* <div style={{paddingLeft:'1px'}}> */}
+                <Button
+                  href={`/dashboard/prompts/${pkg?.id}`}
+                  style={{
+                    accentColor: "black",
+                    borderColor: "GrayText",
+                    borderRadius: "25px",
+                    padding: 0,
+                    textTransform: "none",
+                  }}
+                >
+                  View
+                </Button>
+                <Button
+                  href={`/dashboard/prompts/${pkg?.id}/logs`}
+                  style={{
+                    accentColor: "black",
+                    borderColor: "GrayText",
+                    borderRadius: "25px",
+                    padding: 0,
+                    textTransform: "none",
+                  }}
+                >
                   Logs
-                </MUILink>
-                <MUILink
+                </Button>
+                {/* <div style={{ padding: 0 }}> */}
+                <Button
                   sx={{ cursor: "pointer" }}
                   onClick={() => handleOpen(pkg!.id)}
+                  style={{
+                    accentColor: "black",
+                    borderColor: "GrayText",
+                    left: 1,
+                    borderRadius: "25px",
+                    padding: "0px",
+                    textTransform: "none",
+                  }}
                 >
                   Edit
-                </MUILink>
+                </Button>
+                {/* </div> */}
               </CardActions>
             </Card>
           </Grid>

--- a/apps/factory/src/pages/dashboard/prompts/index.tsx
+++ b/apps/factory/src/pages/dashboard/prompts/index.tsx
@@ -24,18 +24,15 @@ import toast from "react-hot-toast";
 import { getLayout } from "~/components/Layouts/DashboardLayout";
 import { useRouter } from "next/router";
 
-function Packages() {
-  const [packages, setPackages] = useState<pp[]>();
+function Packages({
+  packages,
+  setPackages,
+}: {
+  packages: Array<pp>;
+  setPackages: any;
+}) {
   const [open, setOpen] = useState(false);
   const [packageId, setPackageId] = useState("");
-  api.prompt.getPackages.useQuery(
-    {},
-    {
-      onSuccess(data: pp[]) {
-        setPackages([...data]);
-      },
-    },
-  );
 
   const mutation = api.prompt.updatePackage.useMutation();
 
@@ -86,101 +83,102 @@ function Packages() {
 
   return (
     <Grid container spacing={1}>
-      {packages && packages.length > 0 ? (
-        packages.map((pkg, index) => (
-          <Grid item key={index} xs={12} sm={6} md={4} lg={3}>
-            <Card>
-              <CardHeader title={pkg?.name} />
-              {pkg?.description ? (
-                <CardContent>
-                  <Typography
-                    variant="body2"
-                    style={{
-                      overflow: "hidden",
-                      height: "40px",
-                      textOverflow: "ellipsis",
-                      display: "-webkit-box",
-                      WebkitBoxOrient: "vertical",
-                      WebkitLineClamp: 2,
-                    }}
-                  >
-                    {truncateDescription(pkg?.description || "", 2)}
-                  </Typography>
-                </CardContent>
-              ) : (
-                <CardContent>
-                  <Typography
-                    variant="body2"
-                    style={{
-                      height: "40px",
-                      alignItems: "center",
-                      alignContent: "center",
-                      paddingBottom: "20px",
-                      fontSize: "17px",
-                      opacity: "60%",
-                    }}
-                  >
-                    {"No description entered"}
-                  </Typography>
-                </CardContent>
-              )}
-              <CardActions>
-                <Chip
-                  sx={{ mr: 2 }}
-                  size="small"
-                  label={pkg?.visibility}
-                  // variant="conti"
-                />
-                {/* <div style={{paddingLeft:'1px'}}> */}
-                <Button
-                  href={`/dashboard/prompts/${pkg?.id}`}
+      {/* {packages && packages.length > 0 ? ( */}
+      {packages.map((pkg, index) => (
+        <Grid item key={index} xs={12} sm={6} md={4} lg={3}>
+          <Card>
+            <CardHeader title={pkg?.name} />
+            {pkg!.description ? (
+              <CardContent>
+                <Typography
+                  variant="body2"
                   style={{
-                    accentColor: "black",
-                    borderColor: "GrayText",
-                    borderRadius: "25px",
-                    padding: 0,
-                    textTransform: "none",
+                    overflow: "hidden",
+                    height: "40px",
+                    textOverflow: "ellipsis",
+                    display: "-webkit-box",
+                    WebkitBoxOrient: "vertical",
+                    WebkitLineClamp: 2,
                   }}
                 >
-                  View
-                </Button>
-                <Button
-                  href={`/dashboard/prompts/${pkg?.id}/logs`}
+                  {truncateDescription(pkg?.description || "", 2)}
+                </Typography>
+              </CardContent>
+            ) : (
+              <CardContent>
+                <Typography
+                  variant="body2"
                   style={{
-                    accentColor: "black",
-                    borderColor: "GrayText",
-                    borderRadius: "25px",
-                    padding: 0,
-                    textTransform: "none",
+                    height: "40px",
+                    alignItems: "center",
+                    alignContent: "center",
+                    paddingBottom: "20px",
+                    fontSize: "17px",
+                    opacity: "60%",
                   }}
                 >
-                  Logs
-                </Button>
-                {/* <div style={{ padding: 0 }}> */}
-                <Button
-                  sx={{ cursor: "pointer" }}
-                  onClick={() => handleOpen(pkg!.id)}
-                  style={{
-                    accentColor: "black",
-                    borderColor: "GrayText",
-                    left: 1,
-                    borderRadius: "25px",
-                    padding: "0px",
-                    textTransform: "none",
-                  }}
-                >
-                  Edit
-                </Button>
-                {/* </div> */}
-              </CardActions>
-            </Card>
-          </Grid>
-        ))
-      ) : (
-        <Grid item xs={12}>
-          <Typography>No cards created</Typography>
+                  {"No description entered"}
+                </Typography>
+              </CardContent>
+            )}
+            <CardActions>
+              <Chip
+                sx={{ mr: 2 }}
+                size="small"
+                label={pkg?.visibility}
+                // variant="conti"
+              />
+              <Button
+                href={`/dashboard/prompts/${pkg?.id}`}
+                style={{
+                  accentColor: "black",
+                  borderColor: "GrayText",
+                  borderRadius: "25px",
+                  padding: 0,
+                  textTransform: "none",
+                }}
+              >
+                View
+              </Button>
+              <Button
+                href={`/dashboard/prompts/${pkg?.id}/logs`}
+                style={{
+                  accentColor: "black",
+                  borderColor: "GrayText",
+                  borderRadius: "25px",
+                  padding: 0,
+                  textTransform: "none",
+                }}
+              >
+                Logs
+              </Button>
+              <Button
+                sx={{ cursor: "pointer" }}
+                onClick={() => handleOpen(pkg!.id)}
+                style={{
+                  accentColor: "black",
+                  borderColor: "GrayText",
+                  left: 1,
+                  borderRadius: "25px",
+                  padding: "0px",
+                  textTransform: "none",
+                }}
+              >
+                Edit
+              </Button>
+            </CardActions>
+          </Card>
         </Grid>
-      )}
+      ))}
+      {/* ) : (
+<Grid
+      container
+      justifyContent="center"
+      alignItems="center"
+      style={{ minHeight: '80vh' }}
+    >
+      </Grid>
+      )} */}
 
       {open === true ? (
         <>
@@ -200,6 +198,7 @@ function Packages() {
 
 const PackageHome = () => {
   const router = useRouter();
+
   const [status, setStatus] = useState("");
   const [customError, setCustomError] = useState({});
 
@@ -228,14 +227,53 @@ const PackageHome = () => {
   });
 
   // console.log("mutate", mutation);
+  const [packages, setPackages] = useState<pp[]>();
+  api.prompt.getPackages.useQuery(
+    {},
+    {
+      onSuccess(data: pp[]) {
+        setPackages([...data]);
+      },
+    },
+  );
+
   return (
     <>
-      <CreatePackage
-        onSubmit={mutation.mutate}
-        status={status}
-        customError={customError}
-      ></CreatePackage>
-      <Packages />
+      {packages && packages.length > 0 ? (
+        <>
+          <CreatePackage
+            onSubmit={mutation.mutate}
+            status={status}
+            customError={customError}
+            PackagesExits={true}
+          ></CreatePackage>
+          <Packages packages={packages || []} setPackages={setPackages} />
+        </>
+      ) : (
+        <Grid
+          container
+          justifyContent="center"
+          alignItems="center"
+          style={{ minHeight: "80vh" }}
+        >
+          <Grid item xs={12}>
+            <Typography
+              align="center"
+              fontSize={18}
+              padding={2}
+              fontWeight={700}
+            >
+              No cards created
+            </Typography>
+            <CreatePackage
+              onSubmit={mutation.mutate}
+              status={status}
+              customError={customError}
+              PackagesExits={false}
+            ></CreatePackage>
+          </Grid>
+        </Grid>
+      )}
     </>
   );
 };


### PR DESCRIPTION
Issue -- https://github.com/sugarcane-ai/sugarcane-ai/issues/35

- [ ]  All the cards should have a size fixed. ( Done )
- [ ]  Description can also be restricted to 2 lines and then shown …  ( Done )
- [ ]  View and Logs to be made button like Package Type (Changed Link to Button + adjusted the font and padding)
- [ ]  Change the Create Button to Create Prompt Package, Increase the size of the button 
             (Done + Check screenshot and let me know if size needs to be increased more or not)
- [ ]  If no packages are there, add a button to centre of the screen.  
( Made the create button appear conditionally if packages exits it'll be visible at its default position else the button will be visible at the centre of screen )