### PR TITLE
Disabling run-button for empty prompt variables. Closes #72

### DIFF
--- a/apps/factory/src/components/prompt_version.tsx
+++ b/apps/factory/src/components/prompt_version.tsx
@@ -283,7 +283,9 @@ function PromptVersion({
               color="success"
               variant="outlined"
               onClick={handleRun}
-              disabled={template.length <= 10}
+              disabled={
+                template.length <= 10 || pvrs.some((v) => v.value === "")
+              }
               loadingPosition="start"
               startIcon={<PlayArrowIcon />}
               loading={isLoading}


### PR DESCRIPTION
- added a check for Prompt variables.
- Run button is disabled until all prompt variables have some value (value != "")

