### PR TITLE
Disabling run-button for empty prompt variables

### DIFF
--- a/apps/factory/src/components/prompt_template_view.tsx
+++ b/apps/factory/src/components/prompt_template_view.tsx
@@ -149,7 +149,7 @@ const PromptTemplateView: React.FC<PromptTemplateViewProps> = ({
                   color="success"
                   variant="outlined"
                   onClick={session ? handleRun : handleOpen}
-                  // disabled={data?.template.length <= 10}
+                  disabled={pvrs?.some((v) => v.value === "")}
                 >
                   Run
                 </Button>

--- a/apps/factory/src/components/prompt_version.tsx
+++ b/apps/factory/src/components/prompt_version.tsx
@@ -283,7 +283,9 @@ function PromptVersion({
               color="success"
               variant="outlined"
               onClick={handleRun}
-              disabled={template.length <= 10}
+              disabled={
+                template.length <= 10 || pvrs.some((v) => v.value === "")
+              }
               loadingPosition="start"
               startIcon={<PlayArrowIcon />}
               loading={isLoading}


### PR DESCRIPTION
- Run button is disabled until all prompt variables have some value (value != "")
- Disabled for `prompt template` & `sugar cubes`