### PR TITLE
[Sugar Cube] Create the prompt UI which show full length #84

### DIFF
--- a/apps/factory/src/components/prompt_template_view.tsx
+++ b/apps/factory/src/components/prompt_template_view.tsx
@@ -22,6 +22,7 @@ import { useSession, signIn } from "next-auth/react";
 import Link from "@mui/material/Link";
 const isDev = process.env.NODE_ENV === "development";
 import { displayModes, DisplayModes } from "~/validators/base";
+import { FaCaretDown, FaCaretUp } from "react-icons/fa";
 
 interface PromptTemplateViewProps {
   username: string;
@@ -44,6 +45,7 @@ const PromptTemplateView: React.FC<PromptTemplateViewProps> = ({
   const [promptPerformance, setPromptPerformacne] = useState({});
   const [isOpen, setIsOpen] = useState(false);
   const handleOpen = () => setIsOpen(true);
+  const [isTextOpen, setIsTextOpen] = useState(false);
 
   const { data } = api.cube.getPrompt.useQuery({
     username: username,
@@ -120,16 +122,42 @@ const PromptTemplateView: React.FC<PromptTemplateViewProps> = ({
         <div className="dark:border-gray-70  w-full rounded-lg border p-4 shadow sm:p-6">
           {data || !versionOrEnvironment ? (
             <>
-              <h5 className="mb-3 text-base font-semibold text-gray-900 dark:text-white md:text-xl">
+              <h5 className="mb-3 text-base font-semibold text-gray-900 md:text-xl">
                 {data?.description}
               </h5>
               <Box sx={{ m: 1 }}>
                 {pvrs && (
-                  <PromptVariables
-                    vars={pvrs}
-                    onChange={handleVariablesChange}
-                    mode={displayModes.Enum.EDIT}
-                  />
+                  <>
+                    <PromptVariables
+                      vars={pvrs}
+                      onChange={handleVariablesChange}
+                      mode={displayModes.Enum.EDIT}
+                    />
+                    <div style={{ paddingLeft: 15, paddingRight: 15 }}>
+                      <Stack
+                        className="dark:border-gray-60 w-full rounded-lg border p-3 shadow"
+                        onClick={() => setIsTextOpen(!isTextOpen)}
+                        flexDirection={"row"}
+                        // style={{paddingLeft:20, paddingRight:20}}
+                      >
+                        <Box>
+                          {isTextOpen ? (
+                            <FaCaretDown
+                              size={20}
+                              style={{ paddingRight: 5 }}
+                            />
+                          ) : (
+                            <FaCaretUp size={20} style={{ paddingRight: 5 }} />
+                          )}
+                        </Box>
+                        <Typography className="text-gray-500">
+                          {isTextOpen
+                            ? data?.template
+                            : "Click to view prompt Template"}
+                        </Typography>
+                      </Stack>
+                    </div>
+                  </>
                 )}
               </Box>
               <Stack direction="row" spacing={1} sx={{ p: 1 }}>

--- a/apps/factory/src/components/prompt_template_view.tsx
+++ b/apps/factory/src/components/prompt_template_view.tsx
@@ -22,7 +22,7 @@ import { useSession, signIn } from "next-auth/react";
 import Link from "@mui/material/Link";
 const isDev = process.env.NODE_ENV === "development";
 import { displayModes, DisplayModes } from "~/validators/base";
-import { FaCaretDown, FaCaretUp } from "react-icons/fa";
+import Prompt_view_arrow from "./prompt_view_arrow";
 
 interface PromptTemplateViewProps {
   username: string;
@@ -45,7 +45,6 @@ const PromptTemplateView: React.FC<PromptTemplateViewProps> = ({
   const [promptPerformance, setPromptPerformacne] = useState({});
   const [isOpen, setIsOpen] = useState(false);
   const handleOpen = () => setIsOpen(true);
-  const [isTextOpen, setIsTextOpen] = useState(false);
 
   const { data } = api.cube.getPrompt.useQuery({
     username: username,
@@ -133,30 +132,7 @@ const PromptTemplateView: React.FC<PromptTemplateViewProps> = ({
                       onChange={handleVariablesChange}
                       mode={displayModes.Enum.EDIT}
                     />
-                    <div style={{ paddingLeft: 15, paddingRight: 15 }}>
-                      <Stack
-                        className="dark:border-gray-60 w-full rounded-lg border p-3 shadow"
-                        onClick={() => setIsTextOpen(!isTextOpen)}
-                        flexDirection={"row"}
-                        // style={{paddingLeft:20, paddingRight:20}}
-                      >
-                        <Box>
-                          {isTextOpen ? (
-                            <FaCaretDown
-                              size={20}
-                              style={{ paddingRight: 5 }}
-                            />
-                          ) : (
-                            <FaCaretUp size={20} style={{ paddingRight: 5 }} />
-                          )}
-                        </Box>
-                        <Typography className="text-gray-500">
-                          {isTextOpen
-                            ? data?.template
-                            : "Click to view prompt Template"}
-                        </Typography>
-                      </Stack>
-                    </div>
+                    <Prompt_view_arrow PromptTemplate={data!.template} />
                   </>
                 )}
               </Box>

--- a/apps/factory/src/components/prompt_template_view.tsx
+++ b/apps/factory/src/components/prompt_template_view.tsx
@@ -22,7 +22,7 @@ import { useSession, signIn } from "next-auth/react";
 import Link from "@mui/material/Link";
 const isDev = process.env.NODE_ENV === "development";
 import { displayModes, DisplayModes } from "~/validators/base";
-import Prompt_view_arrow from "./prompt_view_arrow";
+import PromptViewArrow from "./prompt_view_arrow";
 
 interface PromptTemplateViewProps {
   username: string;
@@ -127,12 +127,14 @@ const PromptTemplateView: React.FC<PromptTemplateViewProps> = ({
               <Box sx={{ m: 1 }}>
                 {pvrs && (
                   <>
+                    {data && (
+                      <PromptViewArrow promptTemplate={data?.template} />
+                    )}
                     <PromptVariables
                       vars={pvrs}
                       onChange={handleVariablesChange}
                       mode={displayModes.Enum.EDIT}
                     />
-                    <Prompt_view_arrow PromptTemplate={data!.template} />
                   </>
                 )}
               </Box>

--- a/apps/factory/src/components/prompt_view_arrow.tsx
+++ b/apps/factory/src/components/prompt_view_arrow.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from "react";
+import { Stack, Box, Typography } from "@mui/material";
+import { FaCaretDown, FaCaretUp } from "react-icons/fa";
+
+type Prompt_view_arrowProps = {
+  PromptTemplate: string;
+};
+
+const Prompt_view_arrow: React.FC<Prompt_view_arrowProps> = ({
+  PromptTemplate,
+}) => {
+  const [isTextOpen, setIsTextOpen] = useState(false);
+
+  return (
+    <div style={{ paddingLeft: 15, paddingRight: 15 }}>
+      <Stack
+        className="dark:border-gray-60 w-full rounded-lg border p-3 shadow"
+        onClick={() => setIsTextOpen(!isTextOpen)}
+        flexDirection={"row"}
+      >
+        <Box>
+          {isTextOpen ? (
+            <FaCaretDown size={20} style={{ paddingRight: 5 }} />
+          ) : (
+            <FaCaretUp size={20} style={{ paddingRight: 5 }} />
+          )}
+        </Box>
+        <Typography className="text-gray-500">
+          {isTextOpen ? PromptTemplate : "Click to view prompt Template"}
+        </Typography>
+      </Stack>
+    </div>
+  );
+};
+export default Prompt_view_arrow;

--- a/apps/factory/src/components/prompt_view_arrow.tsx
+++ b/apps/factory/src/components/prompt_view_arrow.tsx
@@ -2,12 +2,12 @@ import React, { useState } from "react";
 import { Stack, Box, Typography } from "@mui/material";
 import { FaCaretDown, FaCaretUp } from "react-icons/fa";
 
-type Prompt_view_arrowProps = {
-  PromptTemplate: string;
+type PromptViewArrowProps = {
+  promptTemplate: string;
 };
 
-const Prompt_view_arrow: React.FC<Prompt_view_arrowProps> = ({
-  PromptTemplate,
+const PromptViewArrow: React.FC<PromptViewArrowProps> = ({
+  promptTemplate,
 }) => {
   const [isTextOpen, setIsTextOpen] = useState(false);
 
@@ -26,10 +26,11 @@ const Prompt_view_arrow: React.FC<Prompt_view_arrowProps> = ({
           )}
         </Box>
         <Typography className="text-gray-500">
-          {isTextOpen ? PromptTemplate : "Click to view prompt Template"}
+          {isTextOpen ? promptTemplate : "Click to view prompt Template"}
         </Typography>
       </Stack>
     </div>
   );
 };
-export default Prompt_view_arrow;
+
+export default PromptViewArrow;


### PR DESCRIPTION
Issue -- #84
added an arrow icon which show prompt Template on Sugar Cubes page.
It fetches prompt Template text from api '''api.cube.getPrompt.useQuery()'''
<img width="1115" alt="Screenshot 2023-11-17 at 1 42 00 AM" src="https://github.com/sugarcane-ai/sugarcane-ai/assets/91473234/8da293a4-d9e6-4e1b-b09e-9881f60e137f">
<img width="1120" alt="Screenshot 2023-11-17 at 1 42 19 AM" src="https://github.com/sugarcane-ai/sugarcane-ai/assets/91473234/374e6e9b-107b-47bd-8ecb-bac63c623e5d">
