### PR TITLE
Adding log history to prompt template page

### DIFF
--- a/apps/factory/src/components/prompt_version.tsx
+++ b/apps/factory/src/components/prompt_version.tsx
@@ -46,6 +46,7 @@ import {
 } from "~/generated/prisma-client-zod.ts";
 import PromotOutputLog from "./prompt_output_log";
 import { displayModes } from "~/validators/base";
+import PromptLogTable from "~/pages/dashboard/prompts/[id]/logs";
 
 function PromptVersion({
   ns,
@@ -385,6 +386,16 @@ function PromptVersion({
               )}
             </Stack>
           )}
+        </Box>
+
+        <Box sx={{ m: 1 }} padding={2}>
+          <Typography variant="h6">Log History</Typography>
+          <PromptLogTable
+            showSearchFilters={false}
+            templateIdProp={pt?.id}
+            versionIdProp={pv?.version}
+            itemsPerPage={5}
+          />
         </Box>
       </Box>
     </>

--- a/apps/factory/src/components/prompt_version.tsx
+++ b/apps/factory/src/components/prompt_version.tsx
@@ -46,7 +46,11 @@ import {
 } from "~/generated/prisma-client-zod.ts";
 import PromotOutputLog from "./prompt_output_log";
 import { displayModes } from "~/validators/base";
+<<<<<<< HEAD
 import DownloadButtonImg from "./download_button_img";
+=======
+import PromptLogTable from "~/pages/dashboard/prompts/[id]/logs";
+>>>>>>> f6417f2 (Adding log history to prompt template page)
 
 function PromptVersion({
   ns,
@@ -397,6 +401,16 @@ function PromptVersion({
               )}
             </Stack>
           )}
+        </Box>
+
+        <Box sx={{ m: 1 }} padding={2}>
+          <Typography variant="h6">Log History</Typography>
+          <PromptLogTable
+            showSearchFilters={false}
+            templateIdProp={pt?.id}
+            versionIdProp={pv?.version}
+            itemsPerPage={5}
+          />
         </Box>
       </Box>
     </>

--- a/apps/factory/src/components/prompt_version.tsx
+++ b/apps/factory/src/components/prompt_version.tsx
@@ -90,6 +90,7 @@ function PromptVersion({
   );
   const [isDirty, setIsDirty] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [outputLog, setOutputLog] = useState<GenerateOutput>(null);
   const pvUpdateMutation = api.prompt.updateVersion.useMutation({
     onSuccess: (v) => {
       if (v !== null) {
@@ -176,6 +177,7 @@ function PromptVersion({
         completion_tokens: pl.completion_tokens,
         total_tokens: pl.total_tokens,
       });
+      setOutputLog(pl);
     }
   };
 
@@ -406,10 +408,11 @@ function PromptVersion({
         <Box sx={{ m: 1 }} padding={2}>
           <Typography variant="h6">Log History</Typography>
           <PromptLogTable
-            showSearchFilters={false}
-            templateIdProp={pt?.id}
-            versionIdProp={pv?.version}
+            logModeMax={false}
+            promptTemplateId={pt?.id}
+            promptVersionId={pv?.version}
             itemsPerPage={5}
+            outputLog={outputLog}
           />
         </Box>
       </Box>

--- a/apps/factory/src/pages/dashboard/prompts/[id]/logs/index.tsx
+++ b/apps/factory/src/pages/dashboard/prompts/[id]/logs/index.tsx
@@ -55,6 +55,13 @@ interface PromptLog {
   updatedAt: string;
 }
 
+interface PromptLogTableProps {
+  showSearchFilters: boolean;
+  templateIdProp: string | undefined;
+  versionIdProp: string | undefined;
+  itemsPerPage: number;
+}
+
 export interface FilterOptions {
   environment?: string | undefined;
   llmModel?: string | undefined;
@@ -65,9 +72,12 @@ export interface FilterOptions {
 // type LabelledState = "UNLABELLED" | "SELECTED" | "REJECTED" | "NOTSURE";
 type FinetunedState = "UNPROCESSED" | "PROCESSED";
 
-const itemsPerPage = 10;
-
-const PromptLogTable: NextPageWithLayout = () => {
+const PromptLogTable: NextPageWithLayout<PromptLogTableProps> = ({
+  showSearchFilters = true,
+  templateIdProp = undefined,
+  versionIdProp = undefined,
+  itemsPerPage = 10,
+}) => {
   const router = useRouter();
   const packageId = router.query.id as string;
 
@@ -78,13 +88,14 @@ const PromptLogTable: NextPageWithLayout = () => {
     environment: undefined,
     llmModel: undefined,
     llmProvider: undefined,
-    version: undefined,
+    version: versionIdProp,
   });
 
   const { data, hasNextPage, fetchNextPage, refetch } =
     api.log.getLogs.useInfiniteQuery(
       {
         promptPackageId: packageId,
+        promptTemplateId: templateIdProp,
         perPage: itemsPerPage,
         ...filterOptions,
       },
@@ -128,12 +139,14 @@ const PromptLogTable: NextPageWithLayout = () => {
         onChange={(e) => setSearchText(e.target.value)}
         onKeyDown={(e) => e.key === "Enter" && handleSearch()}
       /> */}
-      <LogSearchFiltering
-        filterOptions={filterOptions}
-        onFilterChange={(newFilterOptions) =>
-          setFilterOptions(newFilterOptions)
-        }
-      />
+      {showSearchFilters && (
+        <LogSearchFiltering
+          filterOptions={filterOptions}
+          onFilterChange={(newFilterOptions) =>
+            setFilterOptions(newFilterOptions)
+          }
+        />
+      )}
 
       <TableContainer component={Paper}>
         <Table>

--- a/apps/factory/src/pages/dashboard/prompts/[id]/logs/index.tsx
+++ b/apps/factory/src/pages/dashboard/prompts/[id]/logs/index.tsx
@@ -54,6 +54,13 @@ interface PromptLog {
   updatedAt: string;
 }
 
+interface PromptLogTableProps {
+  showSearchFilters: boolean;
+  templateIdProp: string | undefined;
+  versionIdProp: string | undefined;
+  itemsPerPage: number;
+}
+
 export interface FilterOptions {
   environment?: string | undefined;
   llmModel?: string | undefined;
@@ -64,9 +71,12 @@ export interface FilterOptions {
 // type LabelledState = "UNLABELLED" | "SELECTED" | "REJECTED" | "NOTSURE";
 type FinetunedState = "UNPROCESSED" | "PROCESSED";
 
-const itemsPerPage = 10;
-
-const PromptLogTable: NextPageWithLayout = () => {
+const PromptLogTable: NextPageWithLayout<PromptLogTableProps> = ({
+  showSearchFilters = true,
+  templateIdProp = undefined,
+  versionIdProp = undefined,
+  itemsPerPage = 10,
+}) => {
   const router = useRouter();
   const packageId = router.query.id as string;
 
@@ -77,13 +87,14 @@ const PromptLogTable: NextPageWithLayout = () => {
     environment: undefined,
     llmModel: undefined,
     llmProvider: undefined,
-    version: undefined,
+    version: versionIdProp,
   });
 
   const { data, hasNextPage, fetchNextPage, refetch } =
     api.log.getLogs.useInfiniteQuery(
       {
         promptPackageId: packageId,
+        promptTemplateId: templateIdProp,
         perPage: itemsPerPage,
         ...filterOptions,
       },
@@ -127,12 +138,14 @@ const PromptLogTable: NextPageWithLayout = () => {
         onChange={(e) => setSearchText(e.target.value)}
         onKeyDown={(e) => e.key === "Enter" && handleSearch()}
       /> */}
-      <LogSearchFiltering
-        filterOptions={filterOptions}
-        onFilterChange={(newFilterOptions) =>
-          setFilterOptions(newFilterOptions)
-        }
-      />
+      {showSearchFilters && (
+        <LogSearchFiltering
+          filterOptions={filterOptions}
+          onFilterChange={(newFilterOptions) =>
+            setFilterOptions(newFilterOptions)
+          }
+        />
+      )}
 
       <TableContainer component={Paper}>
         <Table>

--- a/apps/factory/src/pages/dashboard/prompts/[id]/logs/index.tsx
+++ b/apps/factory/src/pages/dashboard/prompts/[id]/logs/index.tsx
@@ -26,44 +26,43 @@ import {
 } from "~/generated/prisma-client-zod.ts";
 import PromptCompletion from "~/components/prompt_completion";
 import DownloadButtonImg from "~/components/download_button_img";
-import { GenerateOutput } from "~/validators/service";
+import { LogSchema, GenerateOutput } from "~/validators/service";
 import PromotOutputLog from "~/components/prompt_output_log";
 
-
-interface PromptLog {
-  id: string;
-  inputId?: string;
-  prompt: string;
-  version: string;
-  completion: string;
-  llmProvider: string;
-  llmModel: string;
-  llmConfig: {
-    max_tokens: number;
-    temperature: number;
-  };
-  llmModelType: ModelTypeType;
-  latency: number;
-  prompt_tokens: number;
-  environment: string;
-  completion_tokens: number;
-  total_tokens: number;
-  extras: Record<string, any>;
-  labelledState: LabelledStateType;
-  finetunedState: FinetunedState;
-  promptPackageId: string;
-  promptTemplateId: string;
-  promptVersionId: string;
-  createdAt: string;
-  updatedAt: string;
-}
+// interface PromptLog {
+//   id: string;
+//   inputId?: string;
+//   prompt: string;
+//   version: string;
+//   completion: string;
+//   llmProvider: string;
+//   llmModel: string;
+//   llmConfig: {
+//     max_tokens: number;
+//     temperature: number;
+//   };
+//   llmModelType: ModelTypeType;
+//   latency: number;
+//   prompt_tokens: number;
+//   environment: string;
+//   completion_tokens: number;
+//   total_tokens: number;
+//   extras: Record<string, any>;
+//   labelledState: LabelledStateType;
+//   finetunedState: FinetunedState;
+//   promptPackageId: string;
+//   promptTemplateId: string;
+//   promptVersionId: string;
+//   createdAt: string;
+//   updatedAt: string;
+// }
 
 interface PromptLogTableProps {
   logModeMax: boolean;
   promptTemplateId: string | undefined;
   promptVersionId: string | undefined;
   itemsPerPage: number;
-  outputLog: GenerateOutput | undefined;
+  outputLog: LogSchema | null;
 }
 
 export interface FilterOptions {
@@ -86,7 +85,7 @@ const PromptLogTable: NextPageWithLayout<PromptLogTableProps> = ({
   const router = useRouter();
   const packageId = router.query.id as string;
 
-  const [promptLogs, setPromptLogs] = useState<PromptLog[]>([]);
+  const [promptLogs, setPromptLogs] = useState<LogSchema[]>([]);
   const [searchText, setSearchText] = useState<string>("");
 
   const [filterOptions, setFilterOptions] = useState<FilterOptions>({
@@ -135,7 +134,7 @@ const PromptLogTable: NextPageWithLayout<PromptLogTableProps> = ({
             finetunedState: "",
             promptPackageId: "",
             promptPackageVersion: "",
-          } as unknown as PromptLog;
+          } as unknown as LogSchema;
           return [newLog, ...prevLogs];
         });
       }
@@ -186,7 +185,7 @@ const PromptLogTable: NextPageWithLayout<PromptLogTableProps> = ({
               {logModeMax && <TableCell>Environment</TableCell>}
               <TableCell>Latency(in ms)</TableCell>
               <TableCell>Labelled State</TableCell>
-              <TableCell>Finetuned State</TableCell>
+              {/* <TableCell>Finetuned State</TableCell> */}
               {logModeMax && <TableCell>Created At</TableCell>}
               <TableCell>Updated At</TableCell>
               <TableCell></TableCell>
@@ -243,7 +242,7 @@ const PromptLogTable: NextPageWithLayout<PromptLogTableProps> = ({
                     labelledState={log.labelledState}
                   />
                 </TableCell>
-                <TableCell>{log.finetunedState}</TableCell>
+                {/* <TableCell>{log.finetunedState}</TableCell> */}
                 {logModeMax && (
                   <TableCell>
                     <TimeAgo date={log.createdAt} />

--- a/apps/factory/src/pages/dashboard/prompts/[id]/logs/index.tsx
+++ b/apps/factory/src/pages/dashboard/prompts/[id]/logs/index.tsx
@@ -25,7 +25,12 @@ import {
   ModelTypeSchema,
 } from "~/generated/prisma-client-zod.ts";
 import PromptCompletion from "~/components/prompt_completion";
+<<<<<<< HEAD
 import DownloadButtonImg from "~/components/download_button_img";
+=======
+import { GenerateOutput } from "~/validators/service";
+import PromotOutputLog from "~/components/prompt_output_log";
+>>>>>>> 45f3c71 (Automatic population of logs for prompt templates)
 
 interface PromptLog {
   id: string;
@@ -56,10 +61,11 @@ interface PromptLog {
 }
 
 interface PromptLogTableProps {
-  showSearchFilters: boolean;
-  templateIdProp: string | undefined;
-  versionIdProp: string | undefined;
+  logModeMax: boolean;
+  promptTemplateId: string | undefined;
+  promptVersionId: string | undefined;
   itemsPerPage: number;
+  outputLog: GenerateOutput | undefined;
 }
 
 export interface FilterOptions {
@@ -73,10 +79,11 @@ export interface FilterOptions {
 type FinetunedState = "UNPROCESSED" | "PROCESSED";
 
 const PromptLogTable: NextPageWithLayout<PromptLogTableProps> = ({
-  showSearchFilters = true,
-  templateIdProp = undefined,
-  versionIdProp = undefined,
+  logModeMax = true,
+  promptTemplateId = undefined,
+  promptVersionId = undefined,
   itemsPerPage = 10,
+  outputLog = undefined,
 }) => {
   const router = useRouter();
   const packageId = router.query.id as string;
@@ -88,14 +95,14 @@ const PromptLogTable: NextPageWithLayout<PromptLogTableProps> = ({
     environment: undefined,
     llmModel: undefined,
     llmProvider: undefined,
-    version: versionIdProp,
+    version: promptVersionId,
   });
 
   const { data, hasNextPage, fetchNextPage, refetch } =
     api.log.getLogs.useInfiniteQuery(
       {
         promptPackageId: packageId,
-        promptTemplateId: templateIdProp,
+        promptTemplateId: promptTemplateId,
         perPage: itemsPerPage,
         ...filterOptions,
       },
@@ -118,6 +125,25 @@ const PromptLogTable: NextPageWithLayout<PromptLogTableProps> = ({
     refetch();
   }, [searchText, filterOptions]);
 
+  useEffect(() => {
+    if (outputLog) {
+      const logId = outputLog.id;
+      if (!promptLogs.some((log) => log.id === logId)) {
+        setPromptLogs((prevLogs) => {
+          const newLog = {
+            ...outputLog,
+            llmConfig: {},
+            extras: {},
+            finetunedState: "",
+            promptPackageId: "",
+            promptPackageVersion: "",
+          } as unknown as PromptLog;
+          return [newLog, ...prevLogs];
+        });
+      }
+    }
+  }, [outputLog]);
+
   const handleSearch = () => {
     const filteredLogs = promptLogs.filter((log) =>
       log.prompt.toLowerCase().includes(searchText.toLowerCase()),
@@ -139,7 +165,7 @@ const PromptLogTable: NextPageWithLayout<PromptLogTableProps> = ({
         onChange={(e) => setSearchText(e.target.value)}
         onKeyDown={(e) => e.key === "Enter" && handleSearch()}
       /> */}
-      {showSearchFilters && (
+      {logModeMax && (
         <LogSearchFiltering
           filterOptions={filterOptions}
           onFilterChange={(newFilterOptions) =>
@@ -152,36 +178,41 @@ const PromptLogTable: NextPageWithLayout<PromptLogTableProps> = ({
         <Table>
           <TableHead>
             <TableRow>
-              <TableCell>ID</TableCell>
+              {logModeMax && <TableCell>ID</TableCell>}
               <TableCell>Prompt</TableCell>
               <TableCell>Completion</TableCell>
-              <TableCell>Version</TableCell>
+              {logModeMax && <TableCell>Version</TableCell>}
               <TableCell>LLM Provider</TableCell>
               <TableCell>LLM Model</TableCell>
               <TableCell>Total Tokens</TableCell>
-              <TableCell>Environment</TableCell>
+              {logModeMax && <TableCell>Environment</TableCell>}
               <TableCell>Latency(in ms)</TableCell>
               <TableCell>Labelled State</TableCell>
               <TableCell>Finetuned State</TableCell>
-              <TableCell>Created At</TableCell>
+              {logModeMax && <TableCell>Created At</TableCell>}
               <TableCell>Updated At</TableCell>
+              <TableCell></TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
             {promptLogs.map((log) => (
               <TableRow key={log.id}>
-                <TableCell>{log.id}</TableCell>
+                {logModeMax && <TableCell>{log.id}</TableCell>}
                 <TableCell>
                   {log.prompt}
                   <p>tokens: {log.prompt_tokens}</p>
                 </TableCell>
                 <TableCell
-                  style={{
-                    maxWidth: 150,
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                  }}
+                  style={
+                    logModeMax
+                      ? {
+                          maxWidth: 150,
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }
+                      : { whiteSpace: "normal" }
+                  }
                 >
                   <div
                     style={{
@@ -202,11 +233,11 @@ const PromptLogTable: NextPageWithLayout<PromptLogTableProps> = ({
                     )}
                   </div>
                 </TableCell>
-                <TableCell>{log.version}</TableCell>
+                {logModeMax && <TableCell>{log.version}</TableCell>}
                 <TableCell>{log.llmProvider}</TableCell>
                 <TableCell>{log.llmModel}</TableCell>
                 <TableCell>{log.total_tokens}</TableCell>
-                <TableCell>{log.environment}</TableCell>
+                {logModeMax && <TableCell>{log.environment}</TableCell>}
                 <TableCell>{log.latency}</TableCell>
                 <TableCell>
                   <LabelIcons
@@ -215,11 +246,16 @@ const PromptLogTable: NextPageWithLayout<PromptLogTableProps> = ({
                   />
                 </TableCell>
                 <TableCell>{log.finetunedState}</TableCell>
-                <TableCell>
-                  <TimeAgo date={log.createdAt} />
-                </TableCell>
+                {logModeMax && (
+                  <TableCell>
+                    <TimeAgo date={log.createdAt} />
+                  </TableCell>
+                )}
                 <TableCell>
                   <TimeAgo date={log.updatedAt} />
+                </TableCell>
+                <TableCell>
+                  <PromotOutputLog pl={log} />
                 </TableCell>
               </TableRow>
             ))}

--- a/apps/factory/src/server/api/routers/logs.ts
+++ b/apps/factory/src/server/api/routers/logs.ts
@@ -14,6 +14,7 @@ export const logRouter = createTRPCRouter({
     .query(async ({ ctx, input }) => {
       const {
         promptPackageId,
+        promptTemplateId,
         cursor,
         perPage,
         version,
@@ -24,6 +25,7 @@ export const logRouter = createTRPCRouter({
 
       const baseWhere = {
         promptPackageId,
+        promptTemplateId,
         version,
         environment,
         llmModel,

--- a/apps/factory/src/validators/service.ts
+++ b/apps/factory/src/validators/service.ts
@@ -61,28 +61,29 @@ export const generateInput = z
   .strict();
 export type GenerateInput = z.infer<typeof generateInput>;
 
-export const generateOutput = z
-  .object({
-    id: z.string(),
+export const logSchema = z.object({
+  id: z.string(),
 
-    environment: promptEnvironment,
+  environment: promptEnvironment,
 
-    version: z.string(),
-    prompt: z.string(),
-    completion: z.string(),
+  version: z.string(),
+  prompt: z.string(),
+  completion: z.string(),
 
-    latency: z.number(),
-    prompt_tokens: z.number(),
-    completion_tokens: z.number(),
-    total_tokens: z.number(),
+  latency: z.number(),
+  prompt_tokens: z.number(),
+  completion_tokens: z.number(),
+  total_tokens: z.number(),
 
-    labelledState: LabelledStateSchema,
-    llmProvider: z.string(),
-    llmModel: z.string(),
-    llmModelType: ModelTypeSchema,
+  labelledState: LabelledStateSchema,
+  llmProvider: z.string(),
+  llmModel: z.string(),
+  llmModelType: ModelTypeSchema,
 
-    createdAt: z.coerce.date(),
-    updatedAt: z.coerce.date(),
-  })
-  .or(z.null());
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
+});
+
+export const generateOutput = logSchema.or(z.null());
+export type LogSchema = z.infer<typeof logSchema>;
 export type GenerateOutput = z.infer<typeof generateOutput>;


### PR DESCRIPTION
#### Feature
- Display template and version specific log history for prompt templates.

#### Changes
- Reused PromptLogTable component and added props for enhancing its reusability.
- Added `promptTemplateId` field to getLogs, to receive template specific logs as response. 